### PR TITLE
Define initialize_internals so you don't have to override initialize …

### DIFF
--- a/lib/lackeys/service_base.rb
+++ b/lib/lackeys/service_base.rb
@@ -1,8 +1,11 @@
 module Lackeys
   class ServiceBase
     def initialize(parent)
+      initialize_internals
       @parent = parent
     end
+
+    def initialize_internals; end
 
     def parent; @parent; end
 


### PR DESCRIPTION
…itself
